### PR TITLE
[IMP] open_academy: Include an attendees_ids many2many relation on session model and view T#52898

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -14,6 +14,7 @@
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',
+        'views/partner.xml',
         'views/course.xml',
         'views/session.xml',
         'data/ir_ui_menu.xml',

--- a/open_academy/models/__init__.py
+++ b/open_academy/models/__init__.py
@@ -1,2 +1,3 @@
 from . import course
 from . import session
+from . import partner

--- a/open_academy/models/partner.py
+++ b/open_academy/models/partner.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+    is_instructor = fields.Boolean()
+    session_partner = fields.Many2many('session')

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -6,6 +6,7 @@ class Session(models.Model):
     _description = 'Session'
     course_id = fields.Many2one('course', required=True)
     instructor_id = fields.Many2one('res.partner')
+    attendee_ids = fields.Many2many('res.partner')
     name = fields.Char(required=True)
     start_date = fields.Date()
     duration = fields.Float()

--- a/open_academy/views/partner.xml
+++ b/open_academy/views/partner.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record model="ir.ui.view" id="partner_view_form">
+        <field name="name">partner.view.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sale']" position="before">
+                <group>
+                    <field name="is_instructor"/>
+                    <field name="session_partner"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -6,9 +6,10 @@
       <form>
         <sheet>
           <group>
-             <field name="name"/>
+            <field name="name"/>
             <field name="course_id"/>
             <field name="instructor_id"/>
+            <field name="attendee_ids"/>
           </group>
           <notebook>
             <page string="Start date">
@@ -33,6 +34,7 @@
         <field name="name"/>
         <field name="course_id"/>
         <field name="instructor_id"/>
+        <field name="attendee_ids"/>
         <field name="start_date"/>
         <field name="duration" widget='timesheet_uom'/>
         <field name="number_seat"/>
@@ -47,6 +49,7 @@
         <field name='name'/>
         <field name="course_id"/>
         <field name="instructor_id"/>
+        <field name="attendee_ids"/>
         <field name="start_date"/>
         <field name="duration" widget='timesheet_uom'/>
         <field name="number_seat"/>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -8,7 +8,7 @@
           <group>
             <field name="name"/>
             <field name="course_id"/>
-            <field name="instructor_id"/>
+            <field name="instructor_id" domain="[('is_instructor', '=', 'True')]"/>
             <field name="attendee_ids"/>
           </group>
           <notebook>


### PR DESCRIPTION
**Many2many**
In this pull rquest I worked on the attendees_ids many2many relation to connect the information between res.partner and session model.
![Screenshot from 2022-01-12 12-36-05](https://user-images.githubusercontent.com/90422721/149250185-5de1234e-6256-4f91-9785-73a60e88d564.png)

**Inheritance**
Then I worked on add is_instructor and session_partner fields on res.partner using inheritance.
![Screenshot from 2022-01-12 19-31-19](https://user-images.githubusercontent.com/90422721/149250407-4a624d15-8c6c-45ca-933b-709f5ec00bc9.png)

**Basic domain**
In this section I worked on only show thos partners that are instructors in the instructor field.
![Screenshot from 2022-01-12 19-31-06](https://user-images.githubusercontent.com/90422721/149250660-23058553-c602-47ee-bf4e-317288dac509.png)

