### PR TITLE
[IMP] open_academy: Update the start_date to show a default value that depends on the UTC of the user and also I added the is_active field with True as default value to show to the user if session is active or not T#52898

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -22,5 +22,6 @@
     'demo': [
         'demo/course.xml',
         'demo/session.xml',
+        'demo/category.xml',
     ],
 }

--- a/open_academy/demo/category.xml
+++ b/open_academy/demo/category.xml
@@ -1,0 +1,10 @@
+<odoo>
+    <record id="res_partner_teacher_level_1" model="res.partner.category">
+        <field name="name">Teacher / level 1</field>
+        <field name="color" eval="5"/>
+    </record>
+    <record id="res_partner_teacher_level_2" model="res.partner.category">
+        <field name="name">Teacher / level 2</field>
+        <field name="color" eval="6"/>
+    </record>
+</odoo>

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -4,6 +4,10 @@ from odoo import models, fields
 class Course(models.Model):
     _name = 'course'
     _description = 'Course'
+    _sql_constraints = [
+        ('check_title_description', 'CHECK(title<>description)', "The course's title can not be equal to course's description"),
+        ('title_unique', 'UNIQUE(title)', "The course's title exists"),
+    ]
     session_ids = fields.One2many('session', 'course_id')
     responsible_id = fields.Many2one('res.users')
     title = fields.Char(required=True)

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -5,7 +5,10 @@ class Session(models.Model):
     _name = 'session'
     _description = 'Session'
     course_id = fields.Many2one('course', required=True)
-    instructor_id = fields.Many2one('res.partner')
+    instructor_id = fields.Many2one(
+        'res.partner',
+        domain="['|', ('is_instructor', '=', 'True'), ('category_id.name', 'like', 'Teacher'),]",
+    )
     attendee_ids = fields.Many2many('res.partner')
     name = fields.Char(required=True)
     start_date = fields.Date()

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,5 @@
 from odoo import models, fields, api
+from odoo.exceptions import ValidationError
 
 
 class Session(models.Model):
@@ -37,3 +38,9 @@ class Session(models.Model):
                     'message': 'Attendee ids can not be greater than Number seat',
                 }
             }
+
+    @api.constrains('instructor_id', 'attendee_ids')
+    def _check_instructor_on_attendee(self):
+        for record in self:
+            if record.instructor_id in record.attendee_ids:
+                raise ValidationError('Instructor can not be on attendee field')

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -20,3 +20,20 @@ class Session(models.Model):
     def _calculate_percentage_taken_seat(self):
         for record in self:
             record.percentage_taken_seat = (len(record.attendee_ids) / record.number_seat) * 100 if record.number_seat > 0 else 0
+
+    @api.onchange('attendee_ids', 'number_seat')
+    def _onchange_percentage_taken_seat(self):
+        if self.number_seat <= 0:
+            return {
+                'warning':{
+                    'title': 'Value not allowed!',
+                    'message': 'Number seat can not be negative or zero'
+                }
+            }
+        elif len(self.attendee_ids) > self.number_seat:
+            return {
+                'warning': {
+                    'title': 'This course is filled!',
+                    'message': 'Attendee ids can not be greater than Number seat',
+                }
+            }

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class Session(models.Model):
@@ -13,4 +13,10 @@ class Session(models.Model):
     name = fields.Char(required=True)
     start_date = fields.Date()
     duration = fields.Float()
-    number_seat = fields.Integer()
+    number_seat = fields.Integer(default=1, required=True)
+    percentage_taken_seat = fields.Float(compute='_calculate_percentage_taken_seat')
+
+    @api.depends('attendee_ids', 'number_seat')
+    def _calculate_percentage_taken_seat(self):
+        for record in self:
+            record.percentage_taken_seat = (len(record.attendee_ids) / record.number_seat) * 100 if record.number_seat > 0 else 0

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -8,7 +8,7 @@
           <group>
             <field name="name"/>
             <field name="course_id"/>
-            <field name="instructor_id" domain="[('is_instructor', '=', 'True')]"/>
+            <field name="instructor_id"/>
             <field name="attendee_ids"/>
           </group>
           <notebook>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -18,8 +18,15 @@
             <page string="Duration">
                 <field name="duration" widget='timesheet_uom'/>
             </page>
-            <page string="Number of seats">
-              <field name="number_seat"/>
+            <page string="Seats">
+              <group>
+                <group>
+                  <field name="number_seat"/>
+                </group>
+                <group>
+                  <field name="percentage_taken_seat" widget="progressbar"/>
+                </group>
+              </group>
             </page>
           </notebook>
         </sheet>
@@ -38,6 +45,7 @@
         <field name="start_date"/>
         <field name="duration" widget='timesheet_uom'/>
         <field name="number_seat"/>
+        <field name="percentage_taken_seat" widget="progressbar"/>
       </tree>
     </field>
   </record>
@@ -53,6 +61,7 @@
         <field name="start_date"/>
         <field name="duration" widget='timesheet_uom'/>
         <field name="number_seat"/>
+        <field name="percentage_taken_seat"/>
       </search>
     </field>
   </record>


### PR DESCRIPTION
Now, if a user wants to add an instructor in Sessions, the user only can choose those partners if they are instructors or have any "Teacher" tag. Those tags were created in category.xml.
![Screenshot from 2022-01-13 18-11-39](https://user-images.githubusercontent.com/90422721/149435300-c4b3f876-a3ac-4a44-8821-a9d11ffdc08c.png)

Now, the user can put in taken seat how many seats are taken and can see the percentage of taken sets using the progress bar
![Screenshot from 2022-01-13 18-12-12](https://user-images.githubusercontent.com/90422721/149435437-dea86b83-4012-4781-b9b6-50b863c4f56b.png)

Finally, now, the star_date and active fields have default values to show the current date and the session are active.
![Screenshot from 2022-01-13 19-02-22](https://user-images.githubusercontent.com/90422721/149435611-a80fb3d6-cb4b-4455-ab32-9e89f0e2031a.png)
