### PR TITLE
[IMP] open_academy: Add custom filter My courses to show just the current user's courses, also an option to group by responsibles' name T#52898

### DIFF
--- a/open_academy/demo/session.xml
+++ b/open_academy/demo/session.xml
@@ -4,7 +4,7 @@
       <field name='course_id' ref='course_demo1'/>
       <field name='instructor_id' ref='base.res_partner_1'/>
       <field name='start_date'>2022-02-20</field>
-      <field name='duration'>2.5</field>
+      <field name='duration'>2</field>
       <field name='number_seat'>20</field>
     </record>
     <record model='session' id='session_demo2'>

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -3,6 +3,7 @@ from odoo import models, fields
 
 class Course(models.Model):
     _name = 'course'
+    _rec_name = 'title'
     _description = 'Course'
     _sql_constraints = [
         ('check_title_description', 'CHECK(title<>description)', "Title can not be equal to description"),
@@ -10,5 +11,11 @@ class Course(models.Model):
     ]
     session_ids = fields.One2many('session', 'course_id')
     responsible_id = fields.Many2one('res.users')
-    title = fields.Char(required=True)
+    title = fields.Char(required=True, copy=False)
     description = fields.Text()
+
+    def copy_data(self, default=None):
+        res = super().copy_data(default=default)
+        for copy_values in res:
+            copy_values['title'] = 'Copy of [%s]' % self.title
+        return res

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -16,6 +16,7 @@ class Session(models.Model):
     duration = fields.Integer()
     number_seat = fields.Integer(default=1, required=True)
     percentage_taken_seat = fields.Float(compute='_compute_percentage_taken_seat')
+    count_attendee_ids = fields.Integer(compute="_compute_count_attendee_ids", store=True)
 
     @api.depends('attendee_ids', 'number_seat')
     def _compute_percentage_taken_seat(self):
@@ -24,6 +25,11 @@ class Session(models.Model):
                 record.percentage_taken_seat = (len(record.attendee_ids) / record.number_seat) * 100
             else:
                 record.percentage_taken_seat = 0
+
+    @api.depends('attendee_ids')
+    def _compute_count_attendee_ids(self):
+        for record in self:
+            record.count_attendee_ids = len(record.attendee_ids)
 
     @api.onchange('attendee_ids', 'number_seat')
     def _onchange_percentage_taken_seat(self):

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -13,7 +13,7 @@ class Session(models.Model):
     attendee_ids = fields.Many2many('res.partner')
     name = fields.Char(required=True)
     start_date = fields.Date()
-    duration = fields.Float()
+    duration = fields.Integer()
     number_seat = fields.Integer(default=1, required=True)
     percentage_taken_seat = fields.Float(compute='_compute_percentage_taken_seat')
 

--- a/open_academy/views/course.xml
+++ b/open_academy/views/course.xml
@@ -37,6 +37,10 @@
         <field name='title'/>
         <field name="responsible_id"/>
         <field name="description"/>
+        <filter name="my_courses" string="My courses" domain="[('responsible_id', '=', uid)]"/>
+        <group string="Group By">
+          <filter name="group_by_responsible" context="{'group_by': 'responsible_id'}"/>
+        </group>
       </search>
     </field>
   </record>
@@ -44,5 +48,6 @@
     <field name='name'>Course</field>
     <field name='res_model'>course</field>
     <field name='view_mode'>tree,form</field>
+    <field name="context">{'search_default_my_courses': True,}</field>
   </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -97,9 +97,19 @@
       </gantt>
     </field>
   </record>
+  <record id="session_view_graph" model="ir.ui.view">
+    <field name="name">session.view.graph</field>
+    <field name="model">session</field>
+    <field name="arch" type="xml">
+      <graph type="bar">
+        <field name="course_id"/>
+        <field name="count_attendee_ids" type="measure"/>
+      </graph>
+    </field>
+  </record>
   <record id='session_action_display_view' model='ir.actions.act_window'>
     <field name='name'>Session</field>
     <field name='res_model'>session</field>
-    <field name='view_mode'>tree,form,calendar,gantt</field>
+    <field name='view_mode'>tree,form,calendar,gantt,graph</field>
   </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -107,9 +107,41 @@
       </graph>
     </field>
   </record>
+  <record id="session_view_kanban" model="ir.ui.view">
+    <field name="name">session.view.kanban</field>
+    <field name="model">session</field>
+    <field name="arch" type="xml">
+      <kanban default_group_by="course_id">
+        <field name="course_id"/>
+        <templates>
+          <div><field name="course_id"/></div>
+          <t t-name="kanban-box">
+            <div>
+              <h5>Course ID:</h5>
+              <div><field name="course_id"/></div>
+              <h5>Name:</h5>
+              <div><field name='name'/></div>
+              <h5>Instructor ID:</h5>
+              <div><field name="instructor_id"/></div>
+              <h5>Attendee ID:</h5>
+              <div><field name="attendee_ids"/></div>
+              <h5>Start Date:</h5>
+              <div><field name="start_date"/></div>
+              <h5>Duration:</h5>
+              <div><field name="duration"/></div>
+              <h5>Number Seat:</h5>
+              <div><field name="number_seat"/></div>
+              <h5>Percentage Taken Seat:</h5>
+              <div><field name="percentage_taken_seat" widget="progressbar"/></div>
+            </div>
+          </t>
+        </templates>
+      </kanban>
+    </field>
+  </record>
   <record id='session_action_display_view' model='ir.actions.act_window'>
     <field name='name'>Session</field>
     <field name='res_model'>session</field>
-    <field name='view_mode'>tree,form,calendar,gantt,graph</field>
+    <field name='view_mode'>tree,form,calendar,gantt,graph,kanban</field>
   </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -81,9 +81,25 @@
       </search>
     </field>
   </record>
+  <record id="session_view_gantt" model="ir.ui.view">
+    <field name="name">session.view.gantt</field>
+    <field name="model">session</field>
+    <field name="arch" type="xml">
+      <gantt date_start="start_date" date_stop="start_date" default_group_by="instructor_id">
+        <field name='name'/>
+        <field name="course_id"/>
+        <field name="instructor_id"/>
+        <field name="attendee_ids"/>
+        <field name="start_date"/>
+        <field name="duration"/>
+        <field name="number_seat"/>
+        <field name="percentage_taken_seat"/>
+      </gantt>
+    </field>
+  </record>
   <record id='session_action_display_view' model='ir.actions.act_window'>
     <field name='name'>Session</field>
     <field name='res_model'>session</field>
-    <field name='view_mode'>tree,form,calendar</field>
+    <field name='view_mode'>tree,form,calendar,gantt</field>
   </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -49,6 +49,22 @@
       </tree>
     </field>
   </record>
+  <record id="session_view_calendar" model="ir.ui.view">
+    <field name="name">session.view.calendar</field>
+    <field name="model">session</field>
+    <field name="arch" type="xml">
+        <calendar date_start="start_date" hide_time="true" mode="month" quick_add="True">
+          <field name="name"/>
+          <field name="course_id"/>
+          <field name="instructor_id"/>
+          <field name="attendee_ids"/>
+          <field name="start_date"/>
+          <field name="duration" widget='timesheet_uom'/>
+          <field name="number_seat"/>
+          <field name="percentage_taken_seat" widget="progressbar"/>
+        </calendar>
+    </field>
+  </record>
   <record model="ir.ui.view" id="session_view_search">
     <field name="name">session.view.search</field>
     <field name="model">session</field>
@@ -68,6 +84,6 @@
   <record id='session_action_display_view' model='ir.actions.act_window'>
     <field name='name'>Session</field>
     <field name='res_model'>session</field>
-    <field name='view_mode'>tree,form</field>
+    <field name='view_mode'>tree,form,calendar</field>
   </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -16,7 +16,7 @@
               <field name="start_date"/>
             </page>
             <page string="Duration">
-                <field name="duration" widget='timesheet_uom'/>
+                <field name="duration"/>
             </page>
             <page string="Seats">
               <group>
@@ -43,7 +43,7 @@
         <field name="instructor_id"/>
         <field name="attendee_ids"/>
         <field name="start_date"/>
-        <field name="duration" widget='timesheet_uom'/>
+        <field name="duration"/>
         <field name="number_seat"/>
         <field name="percentage_taken_seat" widget="progressbar"/>
       </tree>
@@ -59,7 +59,7 @@
           <field name="instructor_id"/>
           <field name="attendee_ids"/>
           <field name="start_date"/>
-          <field name="duration" widget='timesheet_uom'/>
+          <field name="duration"/>
           <field name="number_seat"/>
           <field name="percentage_taken_seat" widget="progressbar"/>
         </calendar>
@@ -75,7 +75,7 @@
         <field name="instructor_id"/>
         <field name="attendee_ids"/>
         <field name="start_date"/>
-        <field name="duration" widget='timesheet_uom'/>
+        <field name="duration"/>
         <field name="number_seat"/>
         <field name="percentage_taken_seat"/>
       </search>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -37,7 +37,7 @@
     <field name="name">session.view.tree</field>
     <field name="model">session</field>
     <field name="arch" type="xml">
-      <tree>
+      <tree decoration-info='duration&lt;=5' decoration-danger='duration&gt;=15'>
         <field name="name"/>
         <field name="course_id"/>
         <field name="instructor_id"/>


### PR DESCRIPTION
Now, if the user try to put a duplicated course's title, the app handles this constraint remarking the title is a copy.
![Screenshot from 2022-01-17 17-22-08](https://user-images.githubusercontent.com/90422721/149878034-69bbdb42-eb88-47e4-9754-e59b265e7edb.png)

 Also, the tree view of Session menu is going to be colorized by the duration value, if duration is less than 5, the color is blue and if duration is greater than 15, color is red.
![Screenshot from 2022-01-17 18-49-50](https://user-images.githubusercontent.com/90422721/149878319-f02432d3-1654-4486-8fe1-0e155b42ede1.png)

The calendar view was added for the user can see and add new sessions easily.
![Screenshot from 2022-01-17 19-44-05](https://user-images.githubusercontent.com/90422721/149878490-15e8901f-f7b6-4cca-a55d-93f4e77745eb.png)

And, now, the user have a custom filter that shows his / her courses and group by responsiles' names.
![Screenshot from 2022-01-17 23-22-52](https://user-images.githubusercontent.com/90422721/149878708-45b0570e-582c-4202-a7a2-0c3dad18d712.png)
![Screenshot from 2022-01-17 23-28-23](https://user-images.githubusercontent.com/90422721/149878725-6c1f1b63-90c8-4541-95a4-f4a0f8be58c4.png)
