### PR TITLE
[IMP] open_academy: Add the dasboard view tho show the calendar, graph with the count of attendees and information about courses T#52898

### DIFF
--- a/open_academy/__init__.py
+++ b/open_academy/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from . import controllers

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -8,7 +8,10 @@
     'website': 'https://github.com/rolandojduartem/OpenAcademy',
     'category': 'Uncategorized',
     'version': '15.0.1.0.0',
-    'depends': ['base'],
+    'depends': [
+        'base',
+        'board',
+    ],
     'data': [
         'data/res_group.xml',
         'data/ir_rule.xml',
@@ -16,6 +19,7 @@
         'views/partner.xml',
         'views/course.xml',
         'views/session.xml',
+        'report/open_academy_report_views.xml',
         'data/ir_ui_menu.xml',
         'wizards/assign_attendee_sessions.xml',
         'report/session_templates.xml',

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -18,6 +18,8 @@
         'views/session.xml',
         'data/ir_ui_menu.xml',
         'wizards/assign_attendee_sessions.xml',
+        'report/session_templates.xml',
+        'report/session_reports.xml',
     ],
     'demo': [
         'demo/category.xml',

--- a/open_academy/controllers/__init__.py
+++ b/open_academy/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/open_academy/controllers/main.py
+++ b/open_academy/controllers/main.py
@@ -1,0 +1,9 @@
+from odoo import http
+
+
+class DashboardController(http.Controller):
+    """ This controller was created to fix the custom_id error that
+        appeared when the user try to move the dashboard elements """
+    @http.route('/web/view/edit_custom', type='json', auth="user")
+    def edit_custom(self, arch):
+        return {'result': True}

--- a/open_academy/data/ir_ui_menu.xml
+++ b/open_academy/data/ir_ui_menu.xml
@@ -1,5 +1,6 @@
 <odoo>
     <menuitem id='menu_open_academy_root' name='Open Academy' sequence='1'/>
-    <menuitem id='open_academy_course_menu' name='Courses' parent='open_academy.menu_open_academy_root' action='course_action_display_view' sequence='2'/>
-    <menuitem id='open_academy_session_menu' name='Sessions' parent='open_academy.menu_open_academy_root' action='session_action_display_view' sequence='3'/>
+    <menuitem id='open_academy_session_dashboard_menu' name='Reporting' parent='open_academy.menu_open_academy_root' action='session_dashboard_action' sequence='2'/>
+    <menuitem id='open_academy_course_menu' name='Courses' parent='open_academy.menu_open_academy_root' action='course_action_display_view' sequence='3'/>
+    <menuitem id='open_academy_session_menu' name='Sessions' parent='open_academy.menu_open_academy_root' action='session_action_display_view' sequence='4'/>
 </odoo>

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from datetime import timedelta
 
 
 class Session(models.Model):
@@ -12,11 +13,17 @@ class Session(models.Model):
     )
     attendee_ids = fields.Many2many('res.partner')
     name = fields.Char(required=True)
-    start_date = fields.Date()
-    duration = fields.Integer()
+    start_date = fields.Date(default=lambda self: fields.Date.today())
+    end_date = fields.Date(compute='_compute_end_date')
+    duration = fields.Integer(default=0)
     number_seat = fields.Integer(default=1, required=True)
     percentage_taken_seat = fields.Float(compute='_compute_percentage_taken_seat')
     count_attendee_ids = fields.Integer(compute="_compute_count_attendee_ids", store=True)
+
+    @api.depends('start_date', 'duration')
+    def _compute_end_date(self):
+        for record in self:
+            record.end_date = record.start_date + timedelta(days=record.duration)
 
     @api.depends('attendee_ids', 'number_seat')
     def _compute_percentage_taken_seat(self):

--- a/open_academy/report/open_academy_report_views.xml
+++ b/open_academy/report/open_academy_report_views.xml
@@ -1,0 +1,43 @@
+<odoo>
+    <record id="action_session_graph" model="ir.actions.act_window">
+        <field name="name">action.session.graph</field>
+        <field name="res_model">session</field>
+        <field name="view_mode">graph</field>
+    </record>
+    <record id="action_session_calendar" model="ir.actions.act_window">
+        <field name="name">action.session.calendar</field>
+        <field name="res_model">session</field>
+        <field name="view_mode">calendar</field>
+    </record>
+    <record id="action_course_tree_form" model="ir.actions.act_window">
+        <field name="name">action.course.tree.form</field>
+        <field name="res_model">course</field>
+        <field name="view_mode">tree, form</field>
+    </record>
+    <record model="ir.ui.view" id="session_dashboard_view">
+        <field name="name">Dashboard</field>
+        <field name="model">board.board</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form>
+                <h1 style="text-align:center">My Dashboard</h1>
+                <board style="1-2">
+                    <column>
+                      <action name="%(action_session_graph)d"/>
+                      <action name="%(action_course_tree_form)d"/>
+                    </column>
+                     <column>
+                      <action name="%(action_session_calendar)d"/>
+                    </column>
+                </board>
+            </form>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="session_dashboard_action">
+        <field name="name">session.dashboard.action</field>
+        <field name="res_model">board.board</field>
+        <field name="view_mode">form</field>
+        <field name="usage">menu</field>
+        <field name="view_id" ref="session_dashboard_view"/>
+    </record>
+</odoo>

--- a/open_academy/report/session_reports.xml
+++ b/open_academy/report/session_reports.xml
@@ -1,0 +1,30 @@
+<odoo>
+    <template id="report_session_date" inherit_id="report_template_session_date">
+        <xpath expr="//div[@name='session_date_header']" position="after">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Start Date</th>
+                        <th>End Date</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><span t-field="session.start_date"/></td>
+                        <td><span t-field="session.end_date"/></td>
+                    </tr>
+                </tbody>
+            </table>
+        </xpath>
+    </template>
+    <record id="report_session_date_action" model="ir.actions.report">
+        <field name="name">Session date</field>
+        <field name="model">session</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">open_academy.report_session_date</field>
+        <field name="report_file">open_academy.report_session_date</field>
+        <field name="print_report_name">'Session Date - %s' % (object.name or 'Attendee').replace('/','')</field>
+        <field name="binding_model_id" ref="model_session"/>
+        <field name="binding_type">report</field>
+    </record>
+</odoo>

--- a/open_academy/report/session_templates.xml
+++ b/open_academy/report/session_templates.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <template id="report_template_session_date">
+        <t t-foreach="docs" t-as="session">
+            <t t-call="web.html_container">
+                <t t-call="web.external_layout">
+                    <div name='session_date_header' class="page">
+                        <h1>Session Information</h1>
+                        <br/>
+                        <h2>
+                            Session name: <span t-field="session.name"/>
+                        </h2>
+                        <h2>
+                            Instructor name: <span t-field="session.instructor_id"/>
+                        </h2>
+                        <br/>
+                        <h3>Important dates:</h3>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
In this pull request, It is available the option to print the dates from session model.
![Screenshot from 2022-01-25 11-13-00](https://user-images.githubusercontent.com/90422721/151025570-72c2146f-4d6a-4219-b4f9-94bdd7c0a80e.png)
![Screenshot from 2022-01-25 11-13-18](https://user-images.githubusercontent.com/90422721/151025600-c2cd0a14-132e-4770-ac47-42f35661d3e4.png)

And also, the main Open Academy tab is the dashboard with the information about the calendar, courses and count of attendees.
![Screenshot from 2022-01-25 11-25-29](https://user-images.githubusercontent.com/90422721/151027617-5171621a-33e8-4510-822b-6c4780ce4bdc.png)


